### PR TITLE
Ajout d'une option pour inverser la navigation dans les replays de FranceTV Pluzz

### DIFF
--- a/plugin.video.FranceTVPluzz/default.py
+++ b/plugin.video.FranceTVPluzz/default.py
@@ -50,6 +50,10 @@ class FranceTVPluzz:
     main plugin class
     """
     debug_mode = False #self.debug_mode
+
+    replay_mode = 1
+    channel_mode = 2
+    categ_mode = 3
     
     def __init__( self, *args, **kwargs ):
         print "==============================="
@@ -90,7 +94,9 @@ class FranceTVPluzz:
             cat=urllib.unquote_plus(params["cat"])
         except:
             pass
-                               
+        
+        self.set_navigation_mode()
+                       
         if self.debug_mode:
             print "Mode: "+str(mode)
             print "URL: "+str(url)
@@ -104,7 +110,7 @@ class FranceTVPluzz:
     
         if mode==None or url==None or len(url)<1:
             self.download_catalog()
-            self.addDir("Replays", "message_FT.json",1,os.path.join(MEDIA_PATH,'replay.png'),'')
+            self.addDir("Replays", "message_FT.json",self.replay_mode,os.path.join(MEDIA_PATH,'replay.png'),'')
             self.addDir("Directs", "message_FT.json",100,os.path.join(MEDIA_PATH,'live.png'),'')
             self.clean_thumbnail(str(url))
             xbmcplugin.setPluginCategory( handle=int( sys.argv[ 1 ] ), category=__language__ ( 30000 ) )
@@ -113,12 +119,12 @@ class FranceTVPluzz:
             xbmcplugin.addSortMethod( handle=int( sys.argv[ 1 ] ), sortMethod=xbmcplugin.SORT_METHOD_LABEL )
         
         elif mode==1:
-            self.addDir("France 1ère", "catch_up_france1.json",2,os.path.join(MEDIA_PATH,'france1.png'),'')
-            self.addDir("France 2", "catch_up_france2.json",2,os.path.join(MEDIA_PATH,'france2.png'),'')
-            self.addDir("France 3", "catch_up_france3.json",2,os.path.join(MEDIA_PATH,'france3.png'),'')
-            self.addDir("France 4", "catch_up_france4.json",2,os.path.join(MEDIA_PATH,'france4.png'),'')
-            self.addDir("France 5", "catch_up_france5.json",2,os.path.join(MEDIA_PATH,'france5.png'),'')
-            self.addDir("France Ô", "catch_up_franceo.json",2,os.path.join(MEDIA_PATH,'franceO.png'),'')
+            self.addDir("France 1ère", "catch_up_france1.json",self.channel_mode,os.path.join(MEDIA_PATH,'france1.png'),'',{},cat)
+            self.addDir("France 2", "catch_up_france2.json",self.channel_mode,os.path.join(MEDIA_PATH,'france2.png'),'',{},cat)
+            self.addDir("France 3", "catch_up_france3.json",self.channel_mode,os.path.join(MEDIA_PATH,'france3.png'),'',{},cat)
+            self.addDir("France 4", "catch_up_france4.json",self.channel_mode,os.path.join(MEDIA_PATH,'france4.png'),'',{},cat)
+            self.addDir("France 5", "catch_up_france5.json",self.channel_mode,os.path.join(MEDIA_PATH,'france5.png'),'',{},cat)
+            self.addDir("France Ô", "catch_up_franceo.json",self.channel_mode,os.path.join(MEDIA_PATH,'franceO.png'),'',{},cat)
             self.clean_thumbnail(str(url))
             xbmcplugin.setPluginCategory( handle=int( sys.argv[ 1 ] ), category=__language__ ( 30000 ) )
             xbmcplugin.endOfDirectory(int(sys.argv[1]))
@@ -134,7 +140,7 @@ class FranceTVPluzz:
                 cat_name          = cat['titre'].encode('utf-8')
                 cat_infos         = {}
                 cat_infos['Plot'] = cat['accroche'].encode('utf-8')
-                self.addDir(cat_name,url,3,'','',cat_infos,cat_name)            
+                self.addDir(cat_name,url,self.categ_mode,'','',cat_infos,cat_name)            
             self.clean_thumbnail(str(url))
             xbmcplugin.setPluginCategory( handle=int( sys.argv[ 1 ] ), category=__language__ ( 30000 ) )
             xbmcplugin.endOfDirectory(int(sys.argv[1]))
@@ -371,6 +377,30 @@ class FranceTVPluzz:
         print "FranceTV Pluzz:self.debug_mode Mode:"
         print self.debug_mode        
         
+    def set_navigation_mode(self):
+        if self.debug_mode:
+            print "FranceTV Pluzz:setting navigation_mode Mode:"
+            print __addon__.getSetting('navigation_mode')        
+        if __addon__.getSetting('navigation_mode') == '0':
+            self.replay_mode = 1
+            self.channel_mode = 2
+            self.categ_mode = 3
+        else:
+            self.replay_mode = 2
+            self.channel_mode = 3
+            self.categ_mode = 1
+        if self.debug_mode:
+            print "FranceTV Pluzz:self.replay_mode Mode:"
+            print self.replay_mode        
+            print "FranceTV Pluzz:self.channel_mode Mode:"
+            print self.channel_mode        
+            print "FranceTV Pluzz:self.categ_mode Mode:"
+            print self.categ_mode        
+        
+    replay_mode = 1
+    channel_mode = 2
+    categ_mode = 3
+    
     
 #######################################################################################################################    
 # BEGIN !

--- a/plugin.video.FranceTVPluzz/resources/language/english/strings.xml
+++ b/plugin.video.FranceTVPluzz/resources/language/english/strings.xml
@@ -8,6 +8,9 @@
   <!--SETTINGS STRINGS -->
   <string id="30010">Advanced</string>
   <string id="30011">Enable debug mode</string>
+  <string id="30020">Replays navigation mode</string>
+  <string id="30021">Channels first</string>
+  <string id="30022">Categories first</string>
   
   
   <!--DIALOG STRINGS -->

--- a/plugin.video.FranceTVPluzz/resources/language/french/strings.xml
+++ b/plugin.video.FranceTVPluzz/resources/language/french/strings.xml
@@ -8,6 +8,9 @@
   <!--SETTINGS STRINGS -->
   <string id="30010">Avancé</string>
   <string id="30011">Activer le débogage</string>
+  <string id="30020">Mode de navigation des replays</string>
+  <string id="30021">Chaines en premier</string>
+  <string id="30022">Catégories en premier</string>
   
   
    <!--DIALOG STRINGS -->

--- a/plugin.video.FranceTVPluzz/resources/settings.xml
+++ b/plugin.video.FranceTVPluzz/resources/settings.xml
@@ -6,6 +6,7 @@
     <!-- ADVANCED -->
   	<category label="30010">
 	    <setting label="30011" type="bool" id="debug" default="false" />
+	    <setting label="30020" type="enum" id="navigation_mode" lvalues="30021|30022" />
 	</category>
     
     <!-- DOWNLOAD -->


### PR DESCRIPTION
Bonjour,

Tout d'abord merci pour cet excellent travail qui me permet d'acceder à differents replay sur TV sans passer par une box d'opérateur. C'est vraiment très agréable.
Cependant, je me suis permis d'ajouter une option, qui pour les replays de FranceTV permet de choisir si on préfère naviguer d'abord par la chaine puis la catégorie (par défaut) ou bien par la catégorie puis la chaine (nouvelle navigation).
J'espère que cette petite contribution pourra être utile à d'autres.
N'hésites pas à me faire tes remarques le cas écheant.
Cordialement,

Frédéric
